### PR TITLE
Implemented support for Mac OS X using hidapi.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,16 +19,32 @@ ifeq ($(UNAME), Linux)
   SRCS += dbg_lin.c
   LIBS += -ludev
 else
-  BIN = edbg.exe
-  SRCS += dbg_win.c
-  LIBS += -lhid -lsetupapi
+  ifeq ($(UNAME), Darwin)
+    BIN = edbg
+    SRCS += dbg_mac.c
+    LIBS += hidapi/mac/.libs/libhidapi.a
+    LIBS += -framework IOKit
+    LIBS += -framework CoreFoundation
+  else
+    BIN = edbg.exe
+    SRCS += dbg_win.c
+    LIBS += -lhid -lsetupapi
+  endif
 endif
 
 CFLAGS += -W -Wall -O2 -std=gnu99
+CFLAGS += -Wno-unused-parameter -Wno-sign-compare
+CFLAGS += -Ihidapi/hidapi
 
-all: $(SRCS) $(HDRS)
+all: $(SRCS) $(HDRS) hidapi/mac/.libs/libhidapi.a
 	gcc $(CFLAGS) $(SRCS) $(LIBS) -o $(BIN)
 
+hidapi/mac/.libs/libhidapi.a:
+	git clone git://github.com/signal11/hidapi.git
+	cd hidapi && ./bootstrap
+	cd hidapi && ./configure
+	make -Chidapi
+
 clean:
-	-rm $(BIN)
+	rm -rvf $(BIN) hidapi
 

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@ else
     LIBS += hidapi/mac/.libs/libhidapi.a
     LIBS += -framework IOKit
     LIBS += -framework CoreFoundation
+    HIDAPI = hidapi/mac/.libs/libhidapi.a
+    CFLAGS += -Ihidapi/hidapi
   else
     BIN = edbg.exe
     SRCS += dbg_win.c
@@ -34,9 +36,10 @@ endif
 
 CFLAGS += -W -Wall -O2 -std=gnu99
 CFLAGS += -Wno-unused-parameter -Wno-sign-compare
-CFLAGS += -Ihidapi/hidapi
 
-all: $(SRCS) $(HDRS) hidapi/mac/.libs/libhidapi.a
+all: $(BIN)
+	
+$(BIN): $(SRCS) $(HDRS) $(HIDAPI)
 	gcc $(CFLAGS) $(SRCS) $(LIBS) -o $(BIN)
 
 hidapi/mac/.libs/libhidapi.a:

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,6 @@ else
 endif
 
 CFLAGS += -W -Wall -O2 -std=gnu99
-CFLAGS += -Wno-unused-parameter -Wno-sign-compare
 
 all: $(BIN)
 	

--- a/dbg.h
+++ b/dbg.h
@@ -42,6 +42,7 @@ typedef struct
 {
   char     *path;
   char     *serial;
+  wchar_t  *wserial;
   char     *manufacturer;
   char     *product;
 } debugger_t;

--- a/dbg_mac.c
+++ b/dbg_mac.c
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2015, Lourens Rozema <me@LourensRozema.nl>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*- Includes ----------------------------------------------------------------*/
+#include <string.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <wchar.h>
+#include "hidapi.h"
+#include "edbg.h"
+#include "dbg.h"
+
+/*- Definitions -------------------------------------------------------------*/
+#define HID_BUFFER_SIZE   513 // Atmel EDBG expects 512 bytes + 1 byte for report ID
+
+/*- Types -------------------------------------------------------------------*/
+
+/*- Variables ---------------------------------------------------------------*/
+static hid_device *handle = NULL;
+static uint8_t hid_buffer[HID_BUFFER_SIZE];
+
+/*- Implementations ---------------------------------------------------------*/
+
+char * wcstombsdup(const wchar_t * const src) {
+  const int len = wcslen(src);
+  char * const dst = malloc(len+1);
+  if(dst) {
+    wcstombs(dst, src, len);
+    dst[len] = '\0';
+  }
+  return(dst);
+}
+
+//-----------------------------------------------------------------------------
+int dbg_enumerate(debugger_t *debuggers, int size) {
+  int rsize = 0;
+
+  struct hid_device_info *devs, *cur_dev;
+
+  if (hid_init())
+    return -1;
+
+  devs = hid_enumerate(0x0, 0x0);
+  cur_dev = devs;	
+  for(cur_dev = devs; cur_dev && rsize < size; cur_dev = cur_dev->next) {
+    if(DBG_VID == cur_dev->vendor_id && DBG_PID == cur_dev->product_id) {
+      debuggers[rsize].path = strdup(cur_dev->path);
+      debuggers[rsize].serial = cur_dev->serial_number ? wcstombsdup(cur_dev->serial_number) : "<unknown>";
+      debuggers[rsize].wserial = cur_dev->serial_number ? wcsdup(cur_dev->serial_number) : NULL;
+      debuggers[rsize].manufacturer = cur_dev->manufacturer_string ? wcstombsdup(cur_dev->manufacturer_string) : "<unknown>";
+      debuggers[rsize].product = cur_dev->product_string ? wcstombsdup(cur_dev->product_string) : "<unknown>";
+
+      rsize++;
+    }
+  }
+  hid_free_enumeration(devs);
+
+  return rsize;
+}
+
+//-----------------------------------------------------------------------------
+void dbg_open(debugger_t *debugger) {
+  handle = hid_open(DBG_VID, DBG_PID, debugger->wserial);
+  if (!handle)
+    perror_exit("unable to open device");
+}
+
+//-----------------------------------------------------------------------------
+void dbg_close(void) {
+  if (handle)
+    hid_close(handle);
+}
+
+//-----------------------------------------------------------------------------
+int dbg_dap_cmd(uint8_t *data, int size, int rsize) {
+  char cmd = data[0];
+  int res;
+
+  memset(hid_buffer, 0xff, HID_BUFFER_SIZE);
+
+  hid_buffer[0] = 0x00; // Report ID
+  memcpy(&hid_buffer[1], data, rsize);
+
+  res = hid_write(handle, hid_buffer, HID_BUFFER_SIZE/*rsize+1*/); // Atmel EDBG expects 512 bytes
+  if (res < 0) {
+    printf("Error: %ls\n", hid_error(handle));
+    perror_exit("debugger write()");
+  }
+
+  res = hid_read(handle, hid_buffer, sizeof(hid_buffer));
+  if (res < 0)
+    perror_exit("debugger read()");
+
+  check(res, "empty response received");
+
+  check(hid_buffer[0] == cmd, "invalid response received");
+
+  res--;
+  memcpy(data, &hid_buffer[1], (size < res) ? size : res);
+
+  return res;
+}
+

--- a/dbg_mac.c
+++ b/dbg_mac.c
@@ -48,10 +48,12 @@ static uint8_t hid_buffer[HID_BUFFER_SIZE];
 
 /*- Implementations ---------------------------------------------------------*/
 
-char * wcstombsdup(const wchar_t * const src) {
+char * wcstombsdup(const wchar_t * const src)
+{
   const int len = wcslen(src);
   char * const dst = malloc(len+1);
-  if(dst) {
+  if(dst)
+  {
     wcstombs(dst, src, len);
     dst[len] = '\0';
   }
@@ -59,7 +61,8 @@ char * wcstombsdup(const wchar_t * const src) {
 }
 
 //-----------------------------------------------------------------------------
-int dbg_enumerate(debugger_t *debuggers, int size) {
+int dbg_enumerate(debugger_t *debuggers, int size) 
+{
   int rsize = 0;
 
   struct hid_device_info *devs, *cur_dev;
@@ -69,8 +72,10 @@ int dbg_enumerate(debugger_t *debuggers, int size) {
 
   devs = hid_enumerate(0x0, 0x0);
   cur_dev = devs;	
-  for(cur_dev = devs; cur_dev && rsize < size; cur_dev = cur_dev->next) {
-    if(DBG_VID == cur_dev->vendor_id && DBG_PID == cur_dev->product_id) {
+  for(cur_dev = devs; cur_dev && rsize < size; cur_dev = cur_dev->next)
+  {
+    if(DBG_VID == cur_dev->vendor_id && DBG_PID == cur_dev->product_id)
+    {
       debuggers[rsize].path = strdup(cur_dev->path);
       debuggers[rsize].serial = cur_dev->serial_number ? wcstombsdup(cur_dev->serial_number) : "<unknown>";
       debuggers[rsize].wserial = cur_dev->serial_number ? wcsdup(cur_dev->serial_number) : NULL;
@@ -86,20 +91,23 @@ int dbg_enumerate(debugger_t *debuggers, int size) {
 }
 
 //-----------------------------------------------------------------------------
-void dbg_open(debugger_t *debugger) {
+void dbg_open(debugger_t *debugger)
+{
   handle = hid_open(DBG_VID, DBG_PID, debugger->wserial);
   if (!handle)
     perror_exit("unable to open device");
 }
 
 //-----------------------------------------------------------------------------
-void dbg_close(void) {
+void dbg_close(void)
+{
   if (handle)
     hid_close(handle);
 }
 
 //-----------------------------------------------------------------------------
-int dbg_dap_cmd(uint8_t *data, int size, int rsize) {
+int dbg_dap_cmd(uint8_t *data, int size, int rsize)
+{
   char cmd = data[0];
   int res;
 
@@ -109,7 +117,8 @@ int dbg_dap_cmd(uint8_t *data, int size, int rsize) {
   memcpy(&hid_buffer[1], data, rsize);
 
   res = hid_write(handle, hid_buffer, HID_BUFFER_SIZE/*rsize+1*/); // Atmel EDBG expects 512 bytes
-  if (res < 0) {
+  if (res < 0)
+  {
     printf("Error: %ls\n", hid_error(handle));
     perror_exit("debugger write()");
   }


### PR DESCRIPTION
I have implemented support for Mac OS X by adding dbg_mac.c but also using hidapi. I think this is also a nice approach for using hidapi for the other platforms. Then we can suffice with just one dbg.c implementation, probably as simple as renaming dbg_mac.c to dbg.c and modifying the Makefile to also using hidapi on the other architectures. Of course we then still need the if tree in the Makefile to properly setup the linker flags.