### PR TITLE
Adding more Atmel CMSIS-DAP tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ UNAME := $(shell uname)
 
 SRCS = \
   dap.c \
+  dbg.c \
   edbg.c \
   target.c \
   target_cm0p.c \
@@ -37,7 +38,7 @@ endif
 CFLAGS += -W -Wall -O2 -std=gnu99
 
 all: $(BIN)
-	
+
 $(BIN): $(SRCS) $(HDRS) $(HIDAPI)
 	gcc $(CFLAGS) $(SRCS) $(LIBS) -o $(BIN)
 

--- a/dbg.c
+++ b/dbg.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2015, Alex Taradov <alex@taradov.com>
+ * Copyright (c) 2015, Thibaut VIARD
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -26,45 +26,41 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef _DBG_H_
-#define _DBG_H_
+#include "dbg.h"
 
-/*- Includes ----------------------------------------------------------------*/
-#include <stdint.h>
-#include <stdbool.h>
-
-/*- Definitions -------------------------------------------------------------*/
-#define DBG_VID_ATMEL             0x03eb
-#define DBG_PID_ATMEL_EDBG          0x2111
-#define DBG_PID_ATMEL_MEDBG         0x2145
-#define DBG_PID_ATMEL_ICE           0x2141
-#define DBG_PID_ARDUINO_ZERO        0x2157
-
-/*- Types -------------------------------------------------------------------*/
-typedef struct
+/*- Variables ---------------------------------------------------------------*/
+static const uint16_t dap_products_atmel[]=
 {
-  uint16_t vendor_id;
-  const uint16_t* products;
-} dap_vendor_t;
+  DBG_PID_ATMEL_EDBG, DBG_PID_ATMEL_MEDBG, DBG_PID_ATMEL_ICE, DBG_PID_ARDUINO_ZERO, 0
+};
 
-typedef struct
+static const dap_vendor_t dap_vendors[]=
 {
-  char     *path;
-  char     *serial;
-  wchar_t  *wserial;
-  char     *manufacturer;
-  char     *product;
-  uint16_t  VID;
-  uint16_t  PID;
-} debugger_t;
+  { DBG_VID_ATMEL, dap_products_atmel },
+  { 0, 0 } // End of array
+};
 
-/*- Prototypes --------------------------------------------------------------*/
-int dbg_enumerate(debugger_t *debuggers, int size);
-void dbg_open(debugger_t *debugger);
-void dbg_close(void);
-int dbg_dap_cmd(uint8_t *data, int size, int rsize);
+/*- Implementations ---------------------------------------------------------*/
 
-int dbg_validate_dap(uint16_t vendorid, uint16_t productid);
+//-----------------------------------------------------------------------------
+int dbg_validate_dap(uint16_t vendorid, uint16_t productid)
+{
+  int vendor, product;
 
-#endif // _DBG_H_
+  for (vendor=0; dap_vendors[vendor].vendor_id != 0; vendor++)
+  {
+    if (vendorid == dap_vendors[vendor].vendor_id)
+    {
+      // Found vendor, looking for product
+      for (product=0; dap_vendors[vendor].products[product] != 0; product++)
+      {
+        if (productid == dap_vendors[vendor].products[product])
+        {
+          return vendor<<16|product;
+        }
+      }
+    }
+  }
 
+  return -1;
+}

--- a/dbg_lin.c
+++ b/dbg_lin.c
@@ -81,8 +81,7 @@ int dbg_enumerate(debugger_t *debuggers, int size)
     parent = udev_device_get_parent_with_subsystem_devtype(dev, "usb", "usb_device");
     check(parent, "unable to find parent usb device");
 
-    if (DBG_VID == strtol(udev_device_get_sysattr_value(parent, "idVendor"), NULL, 16) &&
-        DBG_PID == strtol(udev_device_get_sysattr_value(parent, "idProduct"), NULL, 16) &&
+    if (dbg_validate_dap(strtol(udev_device_get_sysattr_value(parent, "idVendor"), NULL, 16), strtol(udev_device_get_sysattr_value(parent, "idProduct"), NULL, 16)) != -1 &&
         rsize < size)
     {
       const char *serial = udev_device_get_sysattr_value(parent, "serial");
@@ -93,6 +92,8 @@ int dbg_enumerate(debugger_t *debuggers, int size)
       debuggers[rsize].serial = serial ? strdup(serial) : "<unknown>";
       debuggers[rsize].manufacturer = manufacturer ? strdup(manufacturer) : "<unknown>";
       debuggers[rsize].product = product ? strdup(product) : "<unknown>";
+      debuggers[rsize].VID = strtol(udev_device_get_sysattr_value(parent, "idVendor"), NULL, 16);
+      debuggers[rsize].PID = strtol(udev_device_get_sysattr_value(parent, "idProduct"), NULL, 16);
 
       rsize++;
     }

--- a/dbg_mac.c
+++ b/dbg_mac.c
@@ -61,7 +61,7 @@ char * wcstombsdup(const wchar_t * const src)
 }
 
 //-----------------------------------------------------------------------------
-int dbg_enumerate(debugger_t *debuggers, int size) 
+int dbg_enumerate(debugger_t *debuggers, int size)
 {
   int rsize = 0;
 
@@ -71,16 +71,18 @@ int dbg_enumerate(debugger_t *debuggers, int size)
     return -1;
 
   devs = hid_enumerate(0x0, 0x0);
-  cur_dev = devs;	
+  cur_dev = devs;
   for(cur_dev = devs; cur_dev && rsize < size; cur_dev = cur_dev->next)
   {
-    if(DBG_VID == cur_dev->vendor_id && DBG_PID == cur_dev->product_id)
+    if(dbg_validate_dap(cur_dev->vendor_id, cur_dev->product_id) != -1)
     {
       debuggers[rsize].path = strdup(cur_dev->path);
       debuggers[rsize].serial = cur_dev->serial_number ? wcstombsdup(cur_dev->serial_number) : "<unknown>";
       debuggers[rsize].wserial = cur_dev->serial_number ? wcsdup(cur_dev->serial_number) : NULL;
       debuggers[rsize].manufacturer = cur_dev->manufacturer_string ? wcstombsdup(cur_dev->manufacturer_string) : "<unknown>";
       debuggers[rsize].product = cur_dev->product_string ? wcstombsdup(cur_dev->product_string) : "<unknown>";
+      debuggers[rsize].VID = cur_dev->vendor_id;
+      debuggers[rsize].PID = cur_dev->product_id;
 
       rsize++;
     }
@@ -93,7 +95,7 @@ int dbg_enumerate(debugger_t *debuggers, int size)
 //-----------------------------------------------------------------------------
 void dbg_open(debugger_t *debugger)
 {
-  handle = hid_open(DBG_VID, DBG_PID, debugger->wserial);
+  handle = hid_open(debugger->VID, debugger->PID, debugger->wserial);
   if (!handle)
     perror_exit("unable to open device");
 }

--- a/dbg_win.c
+++ b/dbg_win.c
@@ -30,7 +30,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <windows.h>
-#include <setupapi.h>          
+#include <setupapi.h>
 #include <ddk/hidsdi.h>
 #include <ddk/hidpi.h>
 #include "dbg.h"
@@ -88,7 +88,7 @@ int dbg_enumerate(debugger_t *debuggers, int size)
       hid_attr.Size = sizeof(hid_attr);
       HidD_GetAttributes(handle, &hid_attr);
 
-      if (DBG_VID == hid_attr.VendorID && DBG_PID == hid_attr.ProductID)
+      if (dbg_validate_dap(hid_attr.VendorID, hid_attr.ProductID) != -1)
       {
         wchar_t wstr[MAX_STRING_SIZE];
         char str[MAX_STRING_SIZE];
@@ -106,6 +106,9 @@ int dbg_enumerate(debugger_t *debuggers, int size)
         HidD_GetProductString(handle, (PVOID)wstr, MAX_STRING_SIZE);
         wcstombs(str, wstr, MAX_STRING_SIZE);
         debuggers[rsize].product = strdup(str);
+
+        debuggers[rsize].VID = hid_attr.VendorID;
+        debuggers[rsize].PID = hid_attr.ProductID;
 
         rsize++;
       }


### PR DESCRIPTION
This PR brings not only more Atmel CMSIS-DAP tools but only make the supported list more generic, in case of.

Additional Atmel like EDBG are: mEDBG (SAMD11-XPRO), Atmel-ICE and Arduino Zero EDBG.

Signed-off-by: Thibaut VIARD <aethaniel@sam-geek.org>