### PR TITLE
Adding support of Atmel ATSAM3X and ATSAM3A devices

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ SRCS = \
   edbg.c \
   target.c \
   target_atmel_cm0p.c \
+  target_atmel_cm3.c \
   target_atmel_cm4.c \
   target_atmel_cm7.c
 
@@ -37,7 +38,7 @@ endif
 CFLAGS += -W -Wall -O2 -std=gnu99
 
 all: $(BIN)
-	
+
 $(BIN): $(SRCS) $(HDRS) $(HIDAPI)
 	gcc $(CFLAGS) $(SRCS) $(LIBS) -o $(BIN)
 

--- a/edbg.c
+++ b/edbg.c
@@ -224,9 +224,9 @@ static void print_help(char *name)
   printf("  -p, --program              program the chip\n");
   printf("  -v, --verify               verify memory\n");
   printf("  -k, --lock                 lock the chip (set security bit)\n");
-  printf("  -r, --read                 read the contents of the chip\n");
+  printf("  -r, --read                 read the whole content of the chip flash\n");
   printf("  -f, --file <file>          binary file to be programmed or verified\n");
-  printf("  -t, --target <name>        specify a traget type (use '-t list' for a list of supported target types\n");
+  printf("  -t, --target <name>        specify a target type (use '-t list' for a list of supported target types)\n");
   printf("  -l, --list                 list all available debuggers\n");
   printf("  -s, --serial <number>      use a debugger with a specified serial number\n");
   printf("  -b, --verbose              print verbose messages\n");

--- a/target.c
+++ b/target.c
@@ -37,12 +37,14 @@
 
 /*- Variables ---------------------------------------------------------------*/
 extern target_ops_t target_atmel_cm0p_ops;
+extern target_ops_t target_atmel_cm3_ops;
 extern target_ops_t target_atmel_cm4_ops;
 extern target_ops_t target_atmel_cm7_ops;
 
 static target_t targets[] =
 {
   { "atmel_cm0p",	"Atmel SAM C/D/R series",	&target_atmel_cm0p_ops },
+  { "atmel_cm3",	"Atmel SAM3X/A series",	&target_atmel_cm3_ops },
   { "atmel_cm4",	"Atmel SAM G and SAM4 series",	&target_atmel_cm4_ops },
   { "atmel_cm7",	"Atmel SAM E7x/S7x/V7x series",	&target_atmel_cm7_ops },
   { NULL, NULL, NULL },

--- a/target_atmel_cm3.c
+++ b/target_atmel_cm3.c
@@ -1,0 +1,344 @@
+/*
+ * Copyright (c) 2013-2015, Alex Taradov <alex@taradov.com>
+ * Copyright (c) 2015, Thibaut VIARD for derivative work from original target_atmel_cm4.c and SAM3X/A port
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*- Includes ----------------------------------------------------------------*/
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+#include "target.h"
+#include "edbg.h"
+#include "dap.h"
+
+/*- Definitions -------------------------------------------------------------*/
+#define DHCSR                  0xe000edf0
+#define DEMCR                  0xe000edfc
+#define AIRCR                  0xe000ed0c
+
+#define CHIPID_CIDR            0x400E0940
+#define CHIPID_EXID            0x400E0944
+
+/*
+#define SAM3XA_EEFC0_BASE      0x400E0A00
+#define SAM3XA_EEFC1_BASE      0x400E0C00
+*/
+
+/*
+0x00 EEFC Flash Mode Register      EEFC_FMR   Read-write   0x0
+0x04 EEFC Flash Command Register   EEFC_FCR   Write-only   –
+0x08 EEFC Flash Status Register    EEFC_FSR   Read-only    0x00000001
+0x0C EEFC Flash Result Register    EEFC_FRR   Read-only    0x0
+*/
+#define EEFC_FMR(n)            (0x400e0a00 + (n) * 0x200)
+#define EEFC_FCR(n)            (0x400e0a04 + (n) * 0x200)
+#define EEFC_FSR(n)            (0x400e0a08 + (n) * 0x200)
+#define EEFC_FRR(n)            (0x400e0a0c + (n) * 0x200)
+#define FSR_FRDY               (1ul)
+
+/*
+Get Flash Descriptor                  0x00   GETD
+Write page                            0x01   WP
+Write page and lock                   0x02   WPL
+Erase page and write page             0x03   EWP
+Erase page and write page then lock   0x04   EWPL
+Erase all                             0x05   EA
+Set Lock Bit                          0x08   SLB
+Clear Lock Bit                        0x09   CLB
+Get Lock Bit                          0x0A   GLB
+Set GPNVM Bit                         0x0B   SGPB
+Clear GPNVM Bit                       0x0C   CGPB
+Get GPNVM Bit                         0x0D   GGPB
+Start Read Unique Identifier          0x0E   STUI
+Stop Read Unique Identifier           0x0F   SPUI
+Get CALIB Bit                         0x10   GCALB
+*/
+
+#define CMD_GETD               0x5a000000
+#define CMD_WP                 0x5a000001
+#define CMD_EA                 0x5a000005
+#define CMD_EWP                0x5a000003
+#define CMD_SGPB               0x5a00000b
+
+/*- Types -------------------------------------------------------------------*/
+typedef struct
+{
+  uint32_t  chip_id;
+  uint32_t  chip_exid;
+  char      *name;
+  uint32_t  flash_start;
+  uint32_t  n_planes;
+  uint32_t  flash_size;
+  uint32_t  page_size;
+} device_t;
+
+/*- Variables ---------------------------------------------------------------*/
+static device_t devices[] =
+{
+  { 0x286E0A60, 0x00000000, "ATSAM3X8H",         0x00080000, 2,  256*1024, 256 },
+  { 0x285E0A60, 0x00000000, "ATSAM3X8E",         0x00080000, 2,  256*1024, 256 },
+  { 0x285B0960, 0x00000000, "ATSAM3X4E",         0x00080000, 2,  128*1024, 256 },
+  { 0x284E0A60, 0x00000000, "ATSAM3X8C",         0x00080000, 2,  256*1024, 256 },
+  { 0x284B0960, 0x00000000, "ATSAM3X4C",         0x00080000, 2,  128*1024, 256 },
+  { 0x283E0A60, 0x00000000, "ATSAM3A8C",         0x00080000, 2,  256*1024, 256 },
+  { 0x283B0960, 0x00000000, "ATSAM3A4C",         0x00080000, 2,  128*1024, 256 },
+  { 0, 0, "", 0, 0, 0, 0 },
+};
+
+static device_t *device;
+
+/*- Implementations ---------------------------------------------------------*/
+
+//-----------------------------------------------------------------------------
+static void target_select(void)
+{
+  uint32_t chip_id, chip_exid;
+
+  // Set boot mode GPNVM bit as a workaraound
+  dap_write_word(EEFC_FCR(0), CMD_SGPB | (1 << 8));
+
+  // Stop the core
+  dap_write_word(DHCSR, 0xa05f0003);
+  dap_write_word(DEMCR, 0x00000001);
+  dap_write_word(AIRCR, 0x05fa0004);
+
+  chip_id = dap_read_word(CHIPID_CIDR);
+  chip_exid = dap_read_word(CHIPID_EXID);
+
+  for (device = devices; device->chip_id > 0; device++)
+  {
+    if (device->chip_id == chip_id && device->chip_exid == chip_exid)
+    {
+      uint32_t fl_id, fl_size, fl_page_size, fl_nb_palne, fl_nb_lock;
+
+      verbose("Target: %s\n", device->name);
+
+      for (uint32_t plane = 0; plane < device->n_planes; plane++)
+      {
+        dap_write_word(EEFC_FCR(plane), CMD_GETD);
+        while (0 == (dap_read_word(EEFC_FSR(plane)) & FSR_FRDY));
+
+        fl_id = dap_read_word(EEFC_FRR(plane));
+        check(fl_id, "Cannot read flash descriptor, check Erase pin state");
+
+        fl_size = dap_read_word(EEFC_FRR(plane));
+        check(fl_size == device->flash_size, "Invalid reported Flash size (%d)", fl_size);
+
+        fl_page_size = dap_read_word(EEFC_FRR(plane));
+        check(fl_page_size == device->page_size, "Invalid reported page size (%d)", fl_page_size);
+
+        fl_nb_palne = dap_read_word(EEFC_FRR(plane));
+        for (uint32_t i = 0; i < fl_nb_palne; i++)
+          dap_read_word(EEFC_FRR(plane));
+
+        fl_nb_lock =  dap_read_word(EEFC_FRR(plane));
+        for (uint32_t i = 0; i < fl_nb_lock; i++)
+          dap_read_word(EEFC_FRR(plane));
+      }
+
+      return;
+    }
+  }
+
+  error_exit("unknown target device (CHIP_ID = 0x%08x)", chip_id);
+}
+
+//-----------------------------------------------------------------------------
+static void target_deselect(void)
+{
+  dap_write_word(DHCSR, 0xa05f0000);
+  dap_write_word(DEMCR, 0x00000000);
+  dap_write_word(AIRCR, 0x05fa0004);
+}
+
+//-----------------------------------------------------------------------------
+static void target_erase(void)
+{
+  verbose("Erasing... ");
+
+  for (uint32_t plane = 0; plane < device->n_planes; plane++)
+    dap_write_word(EEFC_FCR(plane), CMD_EA);
+
+  for (uint32_t plane = 0; plane < device->n_planes; plane++)
+    while (0 == (dap_read_word(EEFC_FSR(plane)) & FSR_FRDY));
+
+  verbose("done.\n");
+}
+
+//-----------------------------------------------------------------------------
+static void target_lock(void)
+{
+  verbose("Locking... ");
+
+  // It is enough to lock just one plane to lock the entire device
+  dap_write_word(EEFC_FCR(0), CMD_SGPB | (0 << 8));
+
+  verbose("done.\n");
+}
+
+//-----------------------------------------------------------------------------
+static void target_program(char *name)
+{
+  uint32_t addr = device->flash_start;
+  uint32_t flash_size = device->flash_size * device->n_planes;
+  uint32_t size, number_of_pages, plane;
+  uint32_t offs = 0;
+  uint8_t *buf;
+
+  buf = buf_alloc(flash_size);
+
+  size = load_file(name, buf, flash_size);
+
+  memset(&buf[size], 0xff, flash_size - size);
+
+  verbose("Programming...");
+
+  number_of_pages = (size + device->page_size - 1) / device->page_size;
+
+/*
+  for (uint32_t page = 0; page < number_of_pages; page += 8)
+  {
+    plane = page / (device->flash_size / device->page_size);
+
+    dap_write_word(EEFC_FCR(plane), CMD_EPA | ((page | 1) << 8));
+    while (0 == (dap_read_word(EEFC_FSR(plane)) & FSR_FRDY));
+
+    verbose(".");
+  }
+  verbose(",");
+*/
+
+  for (uint32_t page = 0; page < number_of_pages; page++)
+  {
+    dap_write_block(addr, &buf[offs], device->page_size);
+    addr += device->page_size;
+    offs += device->page_size;
+
+    plane = page / (device->flash_size / device->page_size);
+
+    dap_write_word(EEFC_FCR(plane), CMD_EWP | (page << 8));
+    while (0 == (dap_read_word(EEFC_FSR(plane)) & FSR_FRDY));
+
+    verbose(".");
+  }
+
+  buf_free(buf);
+
+  verbose(" done.\n");
+}
+
+//-----------------------------------------------------------------------------
+static void target_verify(char *name)
+{
+  uint32_t addr = device->flash_start;
+  uint32_t flash_size = device->flash_size * device->n_planes;
+  uint32_t size, block_size;
+  uint32_t offs = 0;
+  uint8_t *bufa, *bufb;
+
+  bufa = buf_alloc(flash_size);
+  bufb = buf_alloc(device->page_size);
+
+  size = load_file(name, bufa, flash_size);
+
+  verbose("Verification...");
+
+  while (size)
+  {
+    dap_read_block(addr, bufb, device->page_size);
+
+    block_size = (size > device->page_size) ? device->page_size : size;
+
+    for (int i = 0; i < (int)block_size; i++)
+    {
+      if (bufa[offs + i] != bufb[i])
+      {
+        verbose("\nat address 0x%x expected 0x%02x, read 0x%02x\n",
+            addr + i, bufa[offs + i], bufb[i]);
+        free(bufa);
+        free(bufb);
+        error_exit("verification failed");
+      }
+    }
+
+    addr += device->page_size;
+    offs += device->page_size;
+    size -= block_size;
+
+    verbose(".");
+  }
+
+  free(bufa);
+  free(bufb);
+
+  verbose(" done.\n");
+}
+
+//-----------------------------------------------------------------------------
+static void target_read(char *name)
+{
+  uint32_t flash_size = device->flash_size * device->n_planes;
+  uint32_t size = flash_size;
+  uint32_t addr = device->flash_start;
+  uint32_t offs = 0;
+  uint8_t *buf;
+
+  buf = buf_alloc(flash_size);
+
+  verbose("Reading...");
+
+  while (size)
+  {
+    dap_read_block(addr, &buf[offs], device->page_size);
+
+    addr += device->page_size;
+    offs += device->page_size;
+    size -= device->page_size;
+
+    verbose(".");
+  }
+
+  save_file(name, buf, flash_size);
+
+  buf_free(buf);
+
+  verbose(" done.\n");
+}
+
+//-----------------------------------------------------------------------------
+target_ops_t target_atmel_cm3_ops =
+{
+  .select   = target_select,
+  .deselect = target_deselect,
+  .erase    = target_erase,
+  .lock     = target_lock,
+  .program  = target_program,
+  .verify   = target_verify,
+  .read     = target_read,
+};
+

--- a/target_atmel_cm3.c
+++ b/target_atmel_cm3.c
@@ -44,43 +44,28 @@
 #define CHIPID_CIDR            0x400E0940
 #define CHIPID_EXID            0x400E0944
 
-/*
-#define SAM3S_EEFC_BASE        0x400E0A00
-#define SAM3S8_EEFC_BASE       0x400E0A00
-#define SAM3SD8_EEFC_BASE      0x400E0A00
-#define SAM3N_EEFC_BASE        0x400E0A00
-
-#define SAM3XA_EEFC0_BASE      0x400E0A00
-#define SAM3XA_EEFC1_BASE      0x400E0C00
-
-#define SAM3U_EEFC0_BASE       0x400E0800
-#define SAM3U_EEFC1_BASE       0x400E0A00
-*/
-
-#define EEFC_BASE              (0x400E0A00) // not the case for SAM3U
+#define EEFC_BASE              (0x400E0A00) // be aware this is not the case for SAM3U!!!
 #define EEFC_FMR(n)            (EEFC_BASE + 0x00 + (n) * 0x200) // EEFC Flash Mode Register      Read-write
 #define EEFC_FCR(n)            (EEFC_BASE + 0x04 + (n) * 0x200) // EEFC Flash Command Register   Write-only
 #define EEFC_FSR(n)            (EEFC_BASE + 0x08 + (n) * 0x200) // EEFC Flash Status Register    Read-only
 #define EEFC_FRR(n)            (EEFC_BASE + 0x0c + (n) * 0x200) // EEFC Flash Result Register    Read-only
 #define FSR_FRDY               (1ul)
 
-enum {
-CMD_GETD  = 0x5a000000, // Get Flash Descriptor
-CMD_WP    = 0x5a000001, // Write page
-CMD_WPL   = 0x5a000002, // Write page and lock
-CMD_EWP   = 0x5a000003, // Erase page and write page
-CMD_EWPL  = 0x5a000004, // Erase page and write page then lock
-CMD_EA    = 0x5a000005, // Erase all
-CMD_SLB   = 0x5a000008, // Set Lock Bit
-CMD_CLB   = 0x5a000009, // Clear Lock Bit
-CMD_GLB   = 0x5a00000A, // Get Lock Bit
-CMD_SGPB  = 0x5a00000B, // Set GPNVM Bit
-CMD_CGPB  = 0x5a00000C, // Clear GPNVM Bit
-CMD_GGPB  = 0x5a00000D, // Get GPNVM Bit
-CMD_STUI  = 0x5a00000E, // Start Read Unique Identifier
-CMD_SPUI  = 0x5a00000F, // Stop Read Unique Identifier
-CMD_GCALB = 0x5a000010  // Get CALIB Bit
-};
+#define CMD_GETD               0x5a000000 // Get Flash Descriptor
+#define CMD_WP                 0x5a000001 // Write page
+#define CMD_WPL                0x5a000002 // Write page and lock
+#define CMD_EWP                0x5a000003 // Erase page and write page
+#define CMD_EWPL               0x5a000004 // Erase page and write page then lock
+#define CMD_EA                 0x5a000005 // Erase all
+#define CMD_SLB                0x5a000008 // Set Lock Bit
+#define CMD_CLB                0x5a000009 // Clear Lock Bit
+#define CMD_GLB                0x5a00000A // Get Lock Bit
+#define CMD_SGPB               0x5a00000B // Set GPNVM Bit
+#define CMD_CGPB               0x5a00000C // Clear GPNVM Bit
+#define CMD_GGPB               0x5a00000D // Get GPNVM Bit
+#define CMD_STUI               0x5a00000E // Start Read Unique Identifier
+#define CMD_SPUI               0x5a00000F // Stop Read Unique Identifier
+#define CMD_GCALB              0x5a000010 // Get CALIB Bit
 
 /*- Types -------------------------------------------------------------------*/
 typedef struct
@@ -216,19 +201,6 @@ static void target_program(char *name)
   verbose("Programming...");
 
   number_of_pages = (size + device->page_size - 1) / device->page_size;
-
-/*
-  for (uint32_t page = 0; page < number_of_pages; page += 8)
-  {
-    plane = page / (device->flash_size / device->page_size);
-
-    dap_write_word(EEFC_FCR(plane), CMD_EPA | ((page | 1) << 8));
-    while (0 == (dap_read_word(EEFC_FSR(plane)) & FSR_FRDY));
-
-    verbose(".");
-  }
-  verbose(",");
-*/
 
   for (uint32_t page = 0; page < number_of_pages; page++)
   {

--- a/target_atmel_cm3.c
+++ b/target_atmel_cm3.c
@@ -53,19 +53,9 @@
 
 #define CMD_GETD               0x5a000000 // Get Flash Descriptor
 #define CMD_WP                 0x5a000001 // Write page
-#define CMD_WPL                0x5a000002 // Write page and lock
 #define CMD_EWP                0x5a000003 // Erase page and write page
-#define CMD_EWPL               0x5a000004 // Erase page and write page then lock
 #define CMD_EA                 0x5a000005 // Erase all
-#define CMD_SLB                0x5a000008 // Set Lock Bit
-#define CMD_CLB                0x5a000009 // Clear Lock Bit
-#define CMD_GLB                0x5a00000A // Get Lock Bit
 #define CMD_SGPB               0x5a00000B // Set GPNVM Bit
-#define CMD_CGPB               0x5a00000C // Clear GPNVM Bit
-#define CMD_GGPB               0x5a00000D // Get GPNVM Bit
-#define CMD_STUI               0x5a00000E // Start Read Unique Identifier
-#define CMD_SPUI               0x5a00000F // Stop Read Unique Identifier
-#define CMD_GCALB              0x5a000010 // Get CALIB Bit
 
 /*- Types -------------------------------------------------------------------*/
 typedef struct

--- a/target_atmel_cm3.c
+++ b/target_atmel_cm3.c
@@ -52,7 +52,6 @@
 #define FSR_FRDY               (1ul)
 
 #define CMD_GETD               0x5a000000 // Get Flash Descriptor
-#define CMD_WP                 0x5a000001 // Write page
 #define CMD_EWP                0x5a000003 // Erase page and write page
 #define CMD_EA                 0x5a000005 // Erase all
 #define CMD_SGPB               0x5a00000B // Set GPNVM Bit


### PR DESCRIPTION
Validated using Atmel-ICE and Arduino Due (ATSAM3X8E) with a 9kb 'Blink' sample application.

Differences with Atmel Cortex-M4 is the lack of Erase Pages EEFC command. This patch uses Erase and Write Page (EWP) instead of WP.

@ataradov, please do not merge as-is, once you will agree on it, I will do some cleanup.

Signed-off-by: Thibaut VIARD <aethaniel@sam-geek.org>