### PR TITLE
Added a programming offset for where in memory the program and verify start

### DIFF
--- a/edbg.c
+++ b/edbg.c
@@ -165,10 +165,11 @@ void buf_free(void *buf)
 }
 
 //-----------------------------------------------------------------------------
-void check_offset(uint32_t row_size, uint32_t flash_size, uint32_t offset)
+void check_offset(uint32_t row_size, uint32_t flash_size, uint32_t file_size, uint32_t offset)
 {
     check(flash_size > offset, "offset is too big for selected chip");
     check(((row_size - 1) & offset) == 0, "offset is not aligned to the flash row");
+    check((file_size + offset) <= flash_size, "file will not fit in flash at selected offset");
 }
 
 //-----------------------------------------------------------------------------
@@ -186,7 +187,7 @@ int load_file(char *name, uint8_t *data, int size)
 
   fstat(fd, &stat);
 
-  check(stat.st_size <= size, "image is too big for the selected chip at selected offset");
+  check(stat.st_size <= size, "image is too big for the selected chip");
 
   rsize = read(fd, data, stat.st_size);
 

--- a/edbg.c
+++ b/edbg.c
@@ -165,6 +165,13 @@ void buf_free(void *buf)
 }
 
 //-----------------------------------------------------------------------------
+void check_offset(uint32_t row_size, uint32_t flash_size, uint32_t offset)
+{
+    check(flash_size > offset, "offset is too big for selected chip");
+    check(((row_size - 1) & offset) == 0, "offset is not aligned to the flash row");
+}
+
+//-----------------------------------------------------------------------------
 int load_file(char *name, uint8_t *data, int size)
 {
   struct stat stat;
@@ -179,7 +186,7 @@ int load_file(char *name, uint8_t *data, int size)
 
   fstat(fd, &stat);
 
-  check(stat.st_size <= size, "image is too big for the selected chip");
+  check(stat.st_size <= size, "image is too big for the selected chip at selected offset");
 
   rsize = read(fd, data, stat.st_size);
 

--- a/edbg.c
+++ b/edbg.c
@@ -68,11 +68,12 @@ static const struct option long_options[] =
   { "target",    required_argument,  0, 't' },
   { "list",      no_argument,        0, 'l' },
   { "serial",    required_argument,  0, 's' },
+  { "offset",    required_argument,  0, 'o' },
   { "verbose",   no_argument,        0, 'b' },
   { 0, 0, 0, 0 }
 };
 
-static const char *short_options = "hepvkrf:t:ls:b";
+static const char *short_options = "hepvkrf:t:ls:o:b";
 
 static bool g_erase = false;
 static bool g_program = false;
@@ -84,6 +85,7 @@ static char *g_serial = NULL;
 static bool g_list = false;
 static char *g_target = NULL;
 static bool g_verbose = false;
+static uint32_t g_offset = 0;
 
 /*- Implementations ---------------------------------------------------------*/
 
@@ -229,6 +231,7 @@ static void print_help(char *name)
   printf("  -t, --target <name>        specify a target type (use '-t list' for a list of supported target types)\n");
   printf("  -l, --list                 list all available debuggers\n");
   printf("  -s, --serial <number>      use a debugger with a specified serial number\n");
+  printf("  -o, --offset <number>      offset in memory at which to start programming\n");
   printf("  -b, --verbose              print verbose messages\n");
   exit(0);
 }
@@ -254,6 +257,7 @@ static void parse_command_line(int argc, char **argv)
       case 'l': g_list = true; break;
       case 's': g_serial = optarg; break;
       case 'b': g_verbose = true; break;
+      case 'o': g_offset = (uint32_t)strtoul(optarg, NULL, 0); break;
       default: exit(1); break;
     }
   }
@@ -338,10 +342,10 @@ int main(int argc, char **argv)
     target->ops->erase();
 
   if (g_program)
-    target->ops->program(g_file);
+    target->ops->program(g_file, g_offset);
 
   if (g_verify)
-    target->ops->verify(g_file);
+    target->ops->verify(g_file, g_offset);
 
   if (g_lock)
     target->ops->lock();

--- a/edbg.h
+++ b/edbg.h
@@ -41,7 +41,7 @@ void *buf_alloc(int size);
 void buf_free(void *buf);
 int load_file(char *name, uint8_t *data, int size);
 void save_file(char *name, uint8_t *data, int size);
-void check_offset(uint32_t row_size, uint32_t flash_size, uint32_t offset);
+void check_offset(uint32_t row_size, uint32_t flash_size, uint32_t file_size, uint32_t offset);
 
 #endif // _EDBG_H_
 

--- a/edbg.h
+++ b/edbg.h
@@ -41,6 +41,7 @@ void *buf_alloc(int size);
 void buf_free(void *buf);
 int load_file(char *name, uint8_t *data, int size);
 void save_file(char *name, uint8_t *data, int size);
+void check_offset(uint32_t row_size, uint32_t flash_size, uint32_t offset);
 
 #endif // _EDBG_H_
 

--- a/target.h
+++ b/target.h
@@ -40,8 +40,8 @@ typedef struct
   void (*deselect)(void);
   void (*erase)(void);
   void (*lock)(void);
-  void (*program)(char *name);
-  void (*verify)(char *name);
+  void (*program)(char *name, uint32_t offset);
+  void (*verify)(char *name, uint32_t offset);
   void (*read)(char *name);
 } target_ops_t;
 

--- a/target_atmel_cm0p.c
+++ b/target_atmel_cm0p.c
@@ -147,9 +147,11 @@ static void target_program(char *name, uint32_t offset)
   if (dap_read_word(DSU_CTRL_STATUS) & 0x00010000)
     error_exit("devices is locked, perform a chip erase before programming");
 
+  check_offset(device->row_size, device->flash_size, offset);
+
   buf = buf_alloc(device->flash_size);
 
-  size = load_file(name, buf, device->flash_size);
+  size = load_file(name, buf, device->flash_size - offset);
 
   memset(&buf[size], 0xff, device->flash_size - size);
 
@@ -193,10 +195,12 @@ static void target_verify(char *name, uint32_t offset)
   if (dap_read_word(DSU_CTRL_STATUS) & 0x00010000)
     error_exit("devices is locked, unable to verify");
 
+  check_offset(device->row_size, device->flash_size, offset);
+
   bufa = buf_alloc(device->flash_size);
   bufb = buf_alloc(device->row_size);
 
-  size = load_file(name, bufa, device->flash_size);
+  size = load_file(name, bufa, device->flash_size - offset);
 
   verbose("Verification (offset 0x%X)...", offset);
 

--- a/target_atmel_cm0p.c
+++ b/target_atmel_cm0p.c
@@ -136,9 +136,9 @@ static void target_lock(void)
 }
 
 //-----------------------------------------------------------------------------
-static void target_program(char *name)
+static void target_program(char *name, uint32_t offset)
 {
-  uint32_t addr = device->flash_start;
+  uint32_t addr = device->flash_start + offset;
   uint32_t size;
   uint32_t offs = 0;
   uint32_t number_of_rows;
@@ -153,7 +153,7 @@ static void target_program(char *name)
 
   memset(&buf[size], 0xff, device->flash_size - size);
 
-  verbose("Programming...");
+  verbose("Programming (offset 0x%X)...", offset);
 
   number_of_rows = (size + device->row_size - 1) / device->row_size;
 
@@ -183,9 +183,9 @@ static void target_program(char *name)
 }
 
 //-----------------------------------------------------------------------------
-static void target_verify(char *name)
+static void target_verify(char *name, uint32_t offset)
 {
-  uint32_t addr = device->flash_start;
+  uint32_t addr = device->flash_start + offset;
   uint32_t size, block_size;
   uint32_t offs = 0;
   uint8_t *bufa, *bufb;
@@ -198,7 +198,7 @@ static void target_verify(char *name)
 
   size = load_file(name, bufa, device->flash_size);
 
-  verbose("Verification...");
+  verbose("Verification (offset 0x%X)...", offset);
 
   while (size)
   {

--- a/target_atmel_cm0p.c
+++ b/target_atmel_cm0p.c
@@ -147,11 +147,12 @@ static void target_program(char *name, uint32_t offset)
   if (dap_read_word(DSU_CTRL_STATUS) & 0x00010000)
     error_exit("devices is locked, perform a chip erase before programming");
 
-  check_offset(device->row_size, device->flash_size, offset);
 
   buf = buf_alloc(device->flash_size);
 
-  size = load_file(name, buf, device->flash_size - offset);
+  size = load_file(name, buf, device->flash_size);
+
+  check_offset(device->row_size, device->flash_size, size, offset);
 
   memset(&buf[size], 0xff, device->flash_size - size);
 
@@ -195,12 +196,12 @@ static void target_verify(char *name, uint32_t offset)
   if (dap_read_word(DSU_CTRL_STATUS) & 0x00010000)
     error_exit("devices is locked, unable to verify");
 
-  check_offset(device->row_size, device->flash_size, offset);
-
   bufa = buf_alloc(device->flash_size);
   bufb = buf_alloc(device->row_size);
 
-  size = load_file(name, bufa, device->flash_size - offset);
+  size = load_file(name, bufa, device->flash_size);
+
+  check_offset(device->row_size, device->flash_size, size, offset);
 
   verbose("Verification (offset 0x%X)...", offset);
 

--- a/target_atmel_cm3.c
+++ b/target_atmel_cm3.c
@@ -181,11 +181,11 @@ static void target_program(char *name, uint32_t offset)
   uint32_t offs = 0;
   uint8_t *buf;
 
-  check_offset(device->page_size, device->flash_size, offset);
-
   buf = buf_alloc(flash_size);
 
   size = load_file(name, buf, flash_size - offset);
+
+  check_offset(device->page_size, device->flash_size, size, offset);
 
   memset(&buf[size], 0xff, flash_size - size);
 
@@ -221,12 +221,12 @@ static void target_verify(char *name, uint32_t offset)
   uint32_t offs = 0;
   uint8_t *bufa, *bufb;
 
-  check_offset(device->page_size, device->flash_size, offset);
-
   bufa = buf_alloc(flash_size);
   bufb = buf_alloc(device->page_size);
 
   size = load_file(name, bufa, flash_size - offset);
+
+  check_offset(device->page_size, device->flash_size, size, offset);
 
   verbose("Verification (offset 0x%X)...", offset);
 

--- a/target_atmel_cm3.c
+++ b/target_atmel_cm3.c
@@ -173,9 +173,9 @@ static void target_lock(void)
 }
 
 //-----------------------------------------------------------------------------
-static void target_program(char *name)
+static void target_program(char *name, uint32_t offset)
 {
-  uint32_t addr = device->flash_start;
+  uint32_t addr = device->flash_start + offset;
   uint32_t flash_size = device->flash_size * device->n_planes;
   uint32_t size, number_of_pages, plane;
   uint32_t offs = 0;
@@ -187,7 +187,7 @@ static void target_program(char *name)
 
   memset(&buf[size], 0xff, flash_size - size);
 
-  verbose("Programming...");
+  verbose("Programming (offset 0x%X)...", offset);
 
   number_of_pages = (size + device->page_size - 1) / device->page_size;
 
@@ -211,9 +211,9 @@ static void target_program(char *name)
 }
 
 //-----------------------------------------------------------------------------
-static void target_verify(char *name)
+static void target_verify(char *name, uint32_t offset)
 {
-  uint32_t addr = device->flash_start;
+  uint32_t addr = device->flash_start + offset;
   uint32_t flash_size = device->flash_size * device->n_planes;
   uint32_t size, block_size;
   uint32_t offs = 0;
@@ -224,7 +224,7 @@ static void target_verify(char *name)
 
   size = load_file(name, bufa, flash_size);
 
-  verbose("Verification...");
+  verbose("Verification (offset 0x%X)...", offset);
 
   while (size)
   {

--- a/target_atmel_cm3.c
+++ b/target_atmel_cm3.c
@@ -181,9 +181,11 @@ static void target_program(char *name, uint32_t offset)
   uint32_t offs = 0;
   uint8_t *buf;
 
+  check_offset(device->page_size, device->flash_size, offset);
+
   buf = buf_alloc(flash_size);
 
-  size = load_file(name, buf, flash_size);
+  size = load_file(name, buf, flash_size - offset);
 
   memset(&buf[size], 0xff, flash_size - size);
 
@@ -219,10 +221,12 @@ static void target_verify(char *name, uint32_t offset)
   uint32_t offs = 0;
   uint8_t *bufa, *bufb;
 
+  check_offset(device->page_size, device->flash_size, offset);
+
   bufa = buf_alloc(flash_size);
   bufb = buf_alloc(device->page_size);
 
-  size = load_file(name, bufa, flash_size);
+  size = load_file(name, bufa, flash_size - offset);
 
   verbose("Verification (offset 0x%X)...", offset);
 

--- a/target_atmel_cm4.c
+++ b/target_atmel_cm4.c
@@ -228,11 +228,11 @@ static void target_program(char *name, uint32_t offset)
   uint32_t offs = 0;
   uint8_t *buf;
 
-  check_offset(device->page_size, device->flash_size, offset);
-
   buf = buf_alloc(flash_size);
 
   size = load_file(name, buf, flash_size - offset);
+
+  check_offset(device->page_size, device->flash_size, size, offset);
 
   memset(&buf[size], 0xff, flash_size - size);
 
@@ -280,12 +280,12 @@ static void target_verify(char *name, uint32_t offset)
   uint32_t offs = 0;
   uint8_t *bufa, *bufb;
 
-  check_offset(device->page_size, device->flash_size, offset);
-
   bufa = buf_alloc(flash_size);
   bufb = buf_alloc(device->page_size);
 
   size = load_file(name, bufa, flash_size - offset);
+
+  check_offset(device->page_size, device->flash_size, size, offset);
 
   verbose("Verification (offset 0x%X)...", offset);
 

--- a/target_atmel_cm4.c
+++ b/target_atmel_cm4.c
@@ -228,9 +228,11 @@ static void target_program(char *name, uint32_t offset)
   uint32_t offs = 0;
   uint8_t *buf;
 
+  check_offset(device->page_size, device->flash_size, offset);
+
   buf = buf_alloc(flash_size);
 
-  size = load_file(name, buf, flash_size);
+  size = load_file(name, buf, flash_size - offset);
 
   memset(&buf[size], 0xff, flash_size - size);
 
@@ -278,10 +280,12 @@ static void target_verify(char *name, uint32_t offset)
   uint32_t offs = 0;
   uint8_t *bufa, *bufb;
 
+  check_offset(device->page_size, device->flash_size, offset);
+
   bufa = buf_alloc(flash_size);
   bufb = buf_alloc(device->page_size);
 
-  size = load_file(name, bufa, flash_size);
+  size = load_file(name, bufa, flash_size - offset);
 
   verbose("Verification (offset 0x%X)...", offset);
 

--- a/target_atmel_cm4.c
+++ b/target_atmel_cm4.c
@@ -220,9 +220,9 @@ static void target_lock(void)
 }
 
 //-----------------------------------------------------------------------------
-static void target_program(char *name)
+static void target_program(char *name, uint32_t offset)
 {
-  uint32_t addr = device->flash_start;
+  uint32_t addr = device->flash_start + offset;
   uint32_t flash_size = device->flash_size * device->n_planes;
   uint32_t size, number_of_pages, plane;
   uint32_t offs = 0;
@@ -234,7 +234,7 @@ static void target_program(char *name)
 
   memset(&buf[size], 0xff, flash_size - size);
 
-  verbose("Programming...");
+  verbose("Programming (offset 0x%X)...", offset);
 
   number_of_pages = (size + device->page_size - 1) / device->page_size;
 
@@ -270,9 +270,9 @@ static void target_program(char *name)
 }
 
 //-----------------------------------------------------------------------------
-static void target_verify(char *name)
+static void target_verify(char *name, uint32_t offset)
 {
-  uint32_t addr = device->flash_start;
+  uint32_t addr = device->flash_start + offset;
   uint32_t flash_size = device->flash_size * device->n_planes;
   uint32_t size, block_size;
   uint32_t offs = 0;
@@ -283,7 +283,7 @@ static void target_verify(char *name)
 
   size = load_file(name, bufa, flash_size);
 
-  verbose("Verification...");
+  verbose("Verification (offset 0x%X)...", offset);
 
   while (size)
   {

--- a/target_atmel_cm7.c
+++ b/target_atmel_cm7.c
@@ -195,9 +195,11 @@ static void target_program(char *name, uint32_t offset)
   uint32_t offs = 0;
   uint8_t *buf;
 
+  check_offset(device->page_size, device->flash_size, offset);
+
   buf = buf_alloc(device->flash_size);
 
-  size = load_file(name, buf, device->flash_size);
+  size = load_file(name, buf, device->flash_size - offset);
 
   memset(&buf[size], 0xff, device->flash_size - size);
 
@@ -243,10 +245,12 @@ static void target_verify(char *name, uint32_t offset)
   uint32_t offs = 0;
   uint8_t *bufa, *bufb;
 
+  check_offset(device->page_size, device->flash_size, offset);
+
   bufa = buf_alloc(device->flash_size);
   bufb = buf_alloc(device->page_size);
 
-  size = load_file(name, bufa, device->flash_size);
+  size = load_file(name, bufa, device->flash_size - offset);
 
   verbose("Verification (offset 0x%X)...", offset);
 

--- a/target_atmel_cm7.c
+++ b/target_atmel_cm7.c
@@ -188,9 +188,9 @@ static void target_lock(void)
 }
 
 //-----------------------------------------------------------------------------
-static void target_program(char *name)
+static void target_program(char *name, uint32_t offset)
 {
-  uint32_t addr = device->flash_start;
+  uint32_t addr = device->flash_start + offset;
   uint32_t size, number_of_pages;
   uint32_t offs = 0;
   uint8_t *buf;
@@ -201,7 +201,7 @@ static void target_program(char *name)
 
   memset(&buf[size], 0xff, device->flash_size - size);
 
-  verbose("Programming...");
+  verbose("Programming (offset 0x%X)...", offset);
 
   number_of_pages = (size + device->page_size - 1) / device->page_size;
 
@@ -236,9 +236,9 @@ static void target_program(char *name)
 }
 
 //-----------------------------------------------------------------------------
-static void target_verify(char *name)
+static void target_verify(char *name, uint32_t offset)
 {
-  uint32_t addr = device->flash_start;
+  uint32_t addr = device->flash_start + offset;
   uint32_t size, block_size;
   uint32_t offs = 0;
   uint8_t *bufa, *bufb;
@@ -248,7 +248,7 @@ static void target_verify(char *name)
 
   size = load_file(name, bufa, device->flash_size);
 
-  verbose("Verification...");
+  verbose("Verification (offset 0x%X)...", offset);
 
   while (size)
   {

--- a/target_atmel_cm7.c
+++ b/target_atmel_cm7.c
@@ -195,11 +195,11 @@ static void target_program(char *name, uint32_t offset)
   uint32_t offs = 0;
   uint8_t *buf;
 
-  check_offset(device->page_size, device->flash_size, offset);
-
   buf = buf_alloc(device->flash_size);
 
   size = load_file(name, buf, device->flash_size - offset);
+
+  check_offset(device->page_size, device->flash_size, size, offset);
 
   memset(&buf[size], 0xff, device->flash_size - size);
 
@@ -245,12 +245,12 @@ static void target_verify(char *name, uint32_t offset)
   uint32_t offs = 0;
   uint8_t *bufa, *bufb;
 
-  check_offset(device->page_size, device->flash_size, offset);
-
   bufa = buf_alloc(device->flash_size);
   bufb = buf_alloc(device->page_size);
 
   size = load_file(name, bufa, device->flash_size - offset);
+
+  check_offset(device->page_size, device->flash_size, size, offset);
 
   verbose("Verification (offset 0x%X)...", offset);
 


### PR DESCRIPTION
This patch just adds a command line option (--offset, -o) that will get added to the address for the program and verify.

I only have a atmel_cm0p target, so that was the only one I could test it on.

I made this change because I want to be able to put my eeprom data in a separate memory section when linking.  This would allow me to output that section as a binary file and program it into the device at the start of the emulated eeprom.