### PR TITLE
Added support for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: c
+
+compiler:
+ - clang
+ - gcc
+
+before_install:
+  - sudo apt-get -y update
+  - sudo apt-get -y install libudev-dev
+
+script:
+  - make all
+


### PR DESCRIPTION
By supplying a simple Travis CI configuration, each and every commit from now on will automatically be checked for compilation using Clang and GCC:

![travis-ci](https://user-images.githubusercontent.com/2611835/35476747-7364f92c-03b5-11e8-9d25-dffbdb612530.png)

This allows you also to trivially reject obviously incorrect pull requests which don't even compile.