### PR TITLE
Improve '--read' documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Options:
   -p, --program              program the chip
   -v, --verify               verify memory
   -k, --lock                 lock the chip (set security bit)
-  -r, --read                 read the contents of the chip
+  -r, --read                 read the contents of the chip (use '-f file' to specify output file name)
   -f, --file <file>          binary file to be programmed or verified
   -t, --target <name>        specify a target type (use '-t list' for a list of supported target types)
   -l, --list                 list all available debuggers

--- a/edbg.c
+++ b/edbg.c
@@ -363,7 +363,7 @@ static void print_help(char *name, char *param)
     printf("  -p, --program              program the chip\n");
     printf("  -v, --verify               verify memory\n");
     printf("  -k, --lock                 lock the chip (set security bit)\n");
-    printf("  -r, --read                 read the whole content of the chip flash\n");
+    printf("  -r, --read                 read the whole content of the chip flash (use '-f file' to specify output file name)\n");
     printf("  -f, --file <file>          binary file to be programmed or verified\n");
     printf("  -t, --target <name>        specify a target type (use '-t list' for a list of supported target types)\n");
     printf("  -l, --list                 list all available debuggers\n");


### PR DESCRIPTION
Up until now, the `--file` documentation only talked about it's relationship to `--program` and `--verify` options. However, `--file` must also be specified when reading a chip's contents.