### PR TITLE
Improve '--file' documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Options:
   -v, --verify               verify memory
   -k, --lock                 lock the chip (set security bit)
   -r, --read                 read the contents of the chip
-  -f, --file <file>          binary file to be programmed or verified
+  -f, --file <file>          binary file to be programmed or verified; also read output file name
   -t, --target <name>        specify a target type (use '-t list' for a list of supported target types)
   -l, --list                 list all available debuggers
   -s, --serial <number>      use a debugger with a specified serial number

--- a/edbg.c
+++ b/edbg.c
@@ -364,7 +364,7 @@ static void print_help(char *name, char *param)
     printf("  -v, --verify               verify memory\n");
     printf("  -k, --lock                 lock the chip (set security bit)\n");
     printf("  -r, --read                 read the whole content of the chip flash\n");
-    printf("  -f, --file <file>          binary file to be programmed or verified\n");
+    printf("  -f, --file <file>          binary file to be programmed or verified; also read output file name\n");
     printf("  -t, --target <name>        specify a target type (use '-t list' for a list of supported target types)\n");
     printf("  -l, --list                 list all available debuggers\n");
     printf("  -s, --serial <number>      use a debugger with a specified serial number\n");


### PR DESCRIPTION
Up until now, the `--file` documentation only talked about it's relationship to `--program` and `--verify` options. However, `--file` must also be specified when reading a chip's contents.