### PR TITLE
Makefile portability improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+ifndef CC
+  CC := gcc
+endif
+
 UNAME := $(shell uname)
 
 SRCS = \
@@ -40,7 +44,7 @@ CFLAGS += -W -Wall -Wextra -O2 -std=gnu11
 all: $(BIN)
 
 $(BIN): $(SRCS) $(HDRS) $(HIDAPI)
-	gcc $(CFLAGS) $(SRCS) $(LIBS) -o $(BIN)
+	$(CC) $(CFLAGS) $(SRCS) $(LIBS) -o $(BIN)
 
 hidapi/mac/.libs/libhidapi.a:
 	git clone git://github.com/signal11/hidapi.git

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ hidapi/mac/.libs/libhidapi.a:
 	git clone git://github.com/signal11/hidapi.git
 	cd hidapi && ./bootstrap
 	cd hidapi && ./configure
-	make -Chidapi
+	$(MAKE) -Chidapi
 
 clean:
 	rm -rvf $(BIN) hidapi

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,9 @@ ifndef CC
   CC := gcc
 endif
 
-UNAME := $(shell uname)
+ifndef UNAME
+  UNAME := $(shell uname)
+endif
 
 SRCS = \
   dap.c \


### PR DESCRIPTION
This set of commits increases the Makefile's portability and use for cross compilation

* Recursive Makefile invocation honors the environment variables
* Possibility to inject custom C compiler (now Travis CI will automatically use clang in the clang build matrix instead of the hardcoded gcc e.g. [job #7.1](https://travis-ci.org/ataradov/edbg/jobs/339563281#L507) vs [job #11.1](https://travis-ci.org/ooxi/edbg/jobs/346328437#L536))
* Possibility to specify a build target different from the host
