### PR TITLE
Use GCC instead of CC environment variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-ifndef CC
-  CC := gcc
+ifndef GCC
+  GCC := gcc
 endif
 
 ifndef UNAME
@@ -46,7 +46,7 @@ CFLAGS += -W -Wall -Wextra -O2 -std=gnu11
 all: $(BIN)
 
 $(BIN): $(SRCS) $(HDRS) $(HIDAPI)
-	$(CC) $(CFLAGS) $(SRCS) $(LIBS) -o $(BIN)
+	$(GCC) $(CFLAGS) $(SRCS) $(LIBS) -o $(BIN)
 
 hidapi/mac/.libs/libhidapi.a:
 	git clone git://github.com/signal11/hidapi.git


### PR DESCRIPTION
Since certain systems defined `CC` as `cc` inside `make`, the `CC ?= gcc` directive did not have the desired effect of using `gcc` unless the user specifies another compiler.

We therefore change the variable name to `GCC`