### PR TITLE
Additional Makefile improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ compiler:
 before_install:
   - sudo apt-get -y update
   - sudo apt-get -y install libudev-dev
+  - export COMPILER=$CC
 
 script:
   - make all

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-ifndef CC
-  CC := gcc
+ifndef COMPILER
+  COMPILER := gcc
 endif
 
 ifndef UNAME
@@ -46,7 +46,7 @@ CFLAGS += -W -Wall -Wextra -O2 -std=gnu11
 all: $(BIN)
 
 $(BIN): $(SRCS) $(HDRS) $(HIDAPI)
-	$(CC) $(CFLAGS) $(SRCS) $(LIBS) -o $(BIN)
+	$(COMPILER) $(CFLAGS) $(SRCS) $(LIBS) -o $(BIN)
 
 hidapi/mac/.libs/libhidapi.a:
 	git clone git://github.com/signal11/hidapi.git

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,5 @@
-ifndef COMPILER
-  COMPILER := gcc
-endif
-
-ifndef UNAME
-  UNAME := $(shell uname)
-endif
+COMPILER ?= gcc
+UNAME ?= $(shell uname)
 
 SRCS = \
   dap.c \


### PR DESCRIPTION
An oversight on my side resulted in the conditional assignment of `CC` not having any effect. We therefore decided in pull request #53 to use the `COMPILER` environment variable for specifying the compiler to be used.

This patch series contains the change to the `COMPILER` environment variable, the use of the concise conditional assignment operator and a patch to the Travis CI build specification to use both GCC and Clang.