### PR TITLE
Cross Compilation on Travis CI [RFC]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,68 @@
 language: c
 
-compiler:
- - clang
- - gcc
+
+# Currently supported targets
+#
+#  - Linux using Clang
+#  - Linux using GCC
+#  - macOS using Clang
+#  - macOS using GCC
+#  - Windows (amd64) using MXE cross compiler
+matrix:
+ include:
+  - os: linux
+    compiler: clang
+    env: TARGET=LINUX_CLANG
+  - os: linux
+    compiler: gcc
+    env: TARGET=LINUX_GCC
+  - os: osx
+    compiler: clang
+    env: TARGET=OSX_CLANG
+  - os: osx
+    compiler: gcc
+    env: TARGET=OSX_GCC
+  - os: linux
+    compiler: gcc
+    env: TARGET=WINDOWS
+
 
 before_install:
-  - sudo apt-get -y update
-  - sudo apt-get -y install libudev-dev
-  - export COMPILER=$CC
+
+  # Windows
+  # =======
+  #
+  # We are using MXE to build a Windows executable using Travis CI. edbg does
+  # not have any dependencies on Windows besides the Windows Driver Development
+  # Kit which will be provided here.
+  #
+  # @see http://mxe.cc/
+  - if [[ "$TARGET" == "WINDOWS" ]]; then
+
+      git clone --branch=v2.5 --depth=1 https://github.com/uic-evl/omicron.git omicron;
+
+      echo "deb http://pkg.mxe.cc/repos/apt/debian jessie main" | sudo tee /etc/apt/sources.list.d/mxeapt.list;
+      sudo apt-key adv --keyserver x-hkp://keyserver.ubuntu.com --recv-keys D43A795B73B16ABE9643FE1AFD8FFF16DB45C6AB;
+
+      sudo apt-get -y update;
+      sudo apt-get -y install mxe-x86-64-w64-mingw32.static-gcc;
+
+      export CC='/usr/lib/mxe/usr/bin/x86_64-w64-mingw32.static-gcc -Iomicron/external/include';
+      export UNAME=Windows;
+    fi
+
+
+  # Linux
+  # =====
+  #
+  # Installing the libudev-dev dependency is sufficient
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      sudo apt-get -y update;
+      sudo apt-get -y install libudev-dev;
+    fi
+
 
 script:
+  - export COMPILER=$CC
   - make all
 

--- a/edbg.c
+++ b/edbg.c
@@ -188,12 +188,16 @@ void perror_exit(char *text)
 //-----------------------------------------------------------------------------
 void sleep_ms(int ms)
 {
+#ifdef _WIN32
+  Sleep(ms);
+#else
   struct timespec ts;
 
   ts.tv_sec = ms / 1000;
   ts.tv_nsec = (ms % 1000) * 1000000;
 
   nanosleep(&ts, NULL);
+#endif
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This patch contains a proof of concept for compiling all targets on Travis CI, thus providing full build converage:

* [Native Linux using Clang](https://travis-ci.org/ooxi/edbg/jobs/346706970)
* [Native Linux using GCC](https://travis-ci.org/ooxi/edbg/jobs/346706971)
* [Native macOS using Clang](https://travis-ci.org/ooxi/edbg/jobs/346706972)
* [Native macOS using GCC](https://travis-ci.org/ooxi/edbg/jobs/346706973)
* [Windows amd64 cross compiled using MXE](https://travis-ci.org/ooxi/edbg/jobs/346706974)

This pull request should be the base for a discussion about how to provide full build coverage. I'm currently trying to find a macOS workstation in order to verify that the generated binary actually works, however I'm confident.

Would you consider such an approach as feasible for merging? What I see critically is the need for an `ifdef` inside `sleep_ms` (since the `nanosleep` label cannot be resolved by the MXE linker) and the need for Windows Driver Development Toolkit headers during the build process.