### PR TITLE
Switch from gnu11 to c11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ else
   endif
 endif
 
-CFLAGS += -W -Wall -Wextra -O2 -std=c11
+CFLAGS += -W -Wall -Wextra -O2 -std=c11 -D_POSIX_C_SOURCE=200809L
 
 all: $(BIN)
 

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ else
   endif
 endif
 
-CFLAGS += -W -Wall -Wextra -O2 -std=gnu11
+CFLAGS += -W -Wall -Wextra -O2 -std=c11
 
 all: $(BIN)
 


### PR DESCRIPTION
Since you fixed the last warnings in 6634745c522bb9d37a05579df72b110ad51657c0, I thought we go a step further and switch from gnu11 to c11.

No source code changes where necessary at all, just the definition of the POSIX C source feature macro to get `nanosleep` and `strdup`.

I have checked with a couple of GCC and clang versions and non complain :-)