### PR TITLE
Include stbool.h and stdint.h in edbg.h

### DIFF
--- a/edbg.h
+++ b/edbg.h
@@ -31,6 +31,8 @@
 
 /*- Includes ----------------------------------------------------------------*/
 #include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
 
 /*- Prototypes --------------------------------------------------------------*/
 void verbose(char *fmt, ...);


### PR DESCRIPTION
Include stdbool.h and stdint.h in edbg.h due to usage of uint8_t and bool in order to use the header independently.