### PR TITLE
Use hidapi from OS instead of vendoring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,25 @@ matrix:
 
 before_install:
 
+  # Linux
+  # =====
+  #
+  # Installing the libudev-dev dependency is sufficient
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+      sudo apt-get -y update;
+      sudo apt-get -y install libudev-dev;
+    fi
+
+
+  # OS X
+  # ====
+  #
+  # Installing the libhidapi via brew
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      brew install hidapi;
+    fi
+
+
   # Windows
   # =======
   #
@@ -40,16 +59,6 @@ before_install:
 
       export CC='x86_64-w64-mingw32-gcc -Iomicron/external/include/ddk';
       export UNAME=Windows;
-    fi
-
-
-  # Linux
-  # =====
-  #
-  # Installing the libudev-dev dependency is sufficient
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      sudo apt-get -y update;
-      sudo apt-get -y install libudev-dev;
     fi
 
 

--- a/Makefile
+++ b/Makefile
@@ -28,11 +28,11 @@ else
   ifeq ($(UNAME), Darwin)
     BIN = edbg
     SRCS += dbg_mac.c
-    LIBS += hidapi/mac/.libs/libhidapi.a
+    LIBS += /usr/local/lib/libhidapi.a
     LIBS += -framework IOKit
     LIBS += -framework CoreFoundation
-    HIDAPI = hidapi/mac/.libs/libhidapi.a
-    CFLAGS += -Ihidapi/hidapi
+    HIDAPI = /usr/local/lib/libhidapi.a
+    CFLAGS += -I/usr/local/include/hidapi
   else
     BIN = edbg.exe
     SRCS += dbg_win.c
@@ -44,15 +44,9 @@ CFLAGS += -W -Wall -Wextra -O2 -std=gnu11
 
 all: $(BIN)
 
-$(BIN): $(SRCS) $(HDRS) $(HIDAPI)
+$(BIN): $(SRCS) $(HDRS)
 	$(COMPILER) $(CFLAGS) $(SRCS) $(LIBS) -o $(BIN)
 
-hidapi/mac/.libs/libhidapi.a:
-	git clone git://github.com/signal11/hidapi.git
-	cd hidapi && ./bootstrap
-	cd hidapi && ./configure
-	$(MAKE) -Chidapi
-
 clean:
-	rm -rvf $(BIN) hidapi
+	rm -rvf $(BIN)
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ you will need:
 
  * Windows: none
  * Linux: libudev-dev
- * Mac OS X: libhidapi (built automatically by a Makefile)
+ * Mac OS X: libhidapi (can be installed via [brew](http://macappstore.org/hidapi/))
 
 ## Usage
 ```


### PR DESCRIPTION
Up until now, hidapi was automatically being downloaded and build as part of edbg. This was unlike all other dependencies and lead to issues like #89.

Since hidapi is [available on brew](http://macappstore.org/hidapi/) we now use the binary library provided by upstream.

*Update:* What I'm not sure about is whether or not to use absolute paths like `/usr/local/lib/` and `/usr/local/include/` in the `Makefile`. Shouldn't those paths be in the default include and library path anyhow? Moreover using absolute paths might prohibit our users to overwrite the library and include paths for this dependency.