### PR TITLE
Print serial number of CM0+ target

### DIFF
--- a/target_atmel_cm0p.c
+++ b/target_atmel_cm0p.c
@@ -66,6 +66,11 @@
 #define DSU_STATUSA_CRSTEXT    (1 << 1)
 #define DSU_STATUSB_PROT       (1 << 0)
 
+#define SERIAL_NUMBER_0        0x0080a00c
+#define SERIAL_NUMBER_1        0x0080a040
+#define SERIAL_NUMBER_2        0x0080a044
+#define SERIAL_NUMBER_3        0x0080a048
+
 #define NVMCTRL_CTRLA          0x41004000
 #define NVMCTRL_CTRLB          0x41004004
 #define NVMCTRL_PARAM          0x41004008
@@ -175,6 +180,7 @@ static void finish_reset(void)
 static void target_select(target_options_t *options)
 {
   uint32_t dsu_did, id, rev;
+  uint32_t serial_number[4];
   bool locked;
 
   reset_with_extension();
@@ -189,6 +195,14 @@ static void target_select(target_options_t *options)
       continue;
 
     verbose("Target: %s (Rev %c)\n", devices[i].name, 'A' + rev);
+
+    serial_number[0] = dap_read_word(SERIAL_NUMBER_0);
+    serial_number[1] = dap_read_word(SERIAL_NUMBER_1);
+    serial_number[2] = dap_read_word(SERIAL_NUMBER_2);
+    serial_number[3] = dap_read_word(SERIAL_NUMBER_3);
+
+    verbose("Serial number: %08x %08x %08x %08x\n",
+        serial_number[0], serial_number[1], serial_number[2], serial_number[3]);
 
     target_device = devices[i];
     target_options = *options;


### PR DESCRIPTION
By printing the serial number of the target acted upon enables a lot of use cases like statistical analysis and tracability. The serial number is read from the devices memory using SWD.

Successfully tested on samd21 hardware as well as verified using datasheet of the following targets:

* [samd09](https://github.com/ataradov/edbg/files/4031781/atmel-42414-sam-d09_datasheet.pdf)
* [samd10](https://github.com/ataradov/edbg/files/4031780/atmel-42242-sam-d10_datasheet.pdf)
* [samd11](https://github.com/ataradov/edbg/files/4031779/atmel-42363-sam-d11_datasheet.pdf)
* [samd20](https://github.com/ataradov/edbg/files/4031778/60001504B.samd20.pdf)
* [samd21](https://github.com/ataradov/edbg/files/4031777/Atmel-42181-SAM-D21_Datasheet.pdf)
* [samc21](https://github.com/ataradov/edbg/files/4031776/Atmel-42365-SAMC21_Datasheet-894213.pdf)
* [saml21](https://github.com/ataradov/edbg/files/4031775/60001477A.saml21.pdf)
* [saml22](https://github.com/ataradov/edbg/files/4031774/60001465A.saml22.pdf)
* [samr21](https://github.com/ataradov/edbg/files/4031773/sam-r21_datasheet.pdf)
* [samr30](https://github.com/ataradov/edbg/files/4031772/70005303b-1108106.samr30.pdf)
* [samda1](https://github.com/ataradov/edbg/files/4031771/40001895A.samda1.pdf)

However the targets samr34 as well as samr35 do not seem to support serial number extraction. I wanted to keep the pull request as small as possible, but I can implement a device discrimation if you want in order to not print wrong serial numbers for unsupported devices.

For my usecase it would be very helpful to be able to read the serial number into a file, however I did not find information about a unique device identification for other targets then CM0+.

Sample output:

```
Debugger: ATMEL EDBG CMSIS-DAP ATML2130021800020377 03.22.01B3 (S)
Clock frequency: 16.0 MHz
Target: SAM D21J18A (Rev D)
Serial number: 41eebbfe 514d3559 34202020 ff0f2a24
Programming.............................................................................. done.
Verification.............................................................................. done.
```