### PR TITLE
Add SAML10D16A device

### DIFF
--- a/target_mchp_cm23.c
+++ b/target_mchp_cm23.c
@@ -127,6 +127,7 @@ typedef struct
 /*- Variables ---------------------------------------------------------------*/
 static device_t devices[] =
 {
+  { 0x20840003, "saml10", "SAM L10D16A",  64*1024, false },
   { 0x20840000, "saml10", "SAM L10E16A",  64*1024, false },
   { 0x20830000, "saml11", "SAM L11E16A",  64*1024, true  },
 };


### PR DESCRIPTION
Hi, I added new device SAML10D16A. It's tested and working.

```
Debugger: ATMEL Atmel-ICE CMSIS-DAP J41800063789 1.0 (SJ)
Clock frequency: 1.0 MHz
ID: 20840003
DEV probed: 20840003
Target: SAM L10D16A (Rev B)
Programming...... done.
Verification...... done.
```