### PR TITLE
Fixed signed compare in dbg_dap_cmd

### DIFF
--- a/dbg_lin.c
+++ b/dbg_lin.c
@@ -190,7 +190,7 @@ int dbg_get_report_size(void)
 //-----------------------------------------------------------------------------
 int dbg_dap_cmd(uint8_t *data, int size, int rsize)
 {
-  char cmd = data[0];
+  uint8_t cmd = data[0];
   int res;
 
   memset(hid_buffer, 0xff, report_size + 1);

--- a/dbg_mac.c
+++ b/dbg_mac.c
@@ -115,7 +115,7 @@ int dbg_get_report_size(void)
 //-----------------------------------------------------------------------------
 int dbg_dap_cmd(uint8_t *data, int size, int rsize)
 {
-  char cmd = data[0];
+  uint8_t cmd = data[0];
   int res;
 
   memset(hid_buffer, 0xff, report_size + 1);

--- a/dbg_win.c
+++ b/dbg_win.c
@@ -178,7 +178,7 @@ int dbg_get_report_size(void)
 //-----------------------------------------------------------------------------
 int dbg_dap_cmd(uint8_t *data, int size, int rsize)
 {
-  char cmd = data[0];
+  uint8_t cmd = data[0];
   DWORD res;
 
   memset(hid_buffer, 0xff, report_size + 1);


### PR DESCRIPTION
Comparing `char` to `uint8_t` fails for DAP commands with different representation in signed and unsigned (like `ID_DAP_VENDOR_0` = `0x80`).