### PR TITLE
Clearly state which argument defines request and response size

### DIFF
--- a/dbg.h
+++ b/dbg.h
@@ -52,7 +52,7 @@ int dbg_enumerate(debugger_t *debuggers, int size);
 void dbg_open(debugger_t *debugger);
 void dbg_close(void);
 int dbg_get_report_size(void);
-int dbg_dap_cmd(uint8_t *data, int size, int rsize);
+int dbg_dap_cmd(uint8_t *data, int resp_size, int req_size);
 
 #endif // _DBG_H_
 

--- a/dbg_lin.c
+++ b/dbg_lin.c
@@ -188,7 +188,7 @@ int dbg_get_report_size(void)
 }
 
 //-----------------------------------------------------------------------------
-int dbg_dap_cmd(uint8_t *data, int size, int rsize)
+int dbg_dap_cmd(uint8_t *data, int resp_size, int req_size)
 {
   uint8_t cmd = data[0];
   int res;
@@ -196,7 +196,7 @@ int dbg_dap_cmd(uint8_t *data, int size, int rsize)
   memset(hid_buffer, 0xff, report_size + 1);
 
   hid_buffer[0] = 0x00; // Report ID
-  memcpy(&hid_buffer[1], data, rsize);
+  memcpy(&hid_buffer[1], data, req_size);
 
   res = write(debugger_fd, hid_buffer, report_size + 1);
   if (res < 0)
@@ -211,7 +211,7 @@ int dbg_dap_cmd(uint8_t *data, int size, int rsize)
   check(hid_buffer[0] == cmd, "invalid response received");
 
   res--;
-  memcpy(data, &hid_buffer[1], (size < res) ? size : res);
+  memcpy(data, &hid_buffer[1], (resp_size < res) ? resp_size : res);
 
   return res;
 }

--- a/dbg_mac.c
+++ b/dbg_mac.c
@@ -113,7 +113,7 @@ int dbg_get_report_size(void)
 }
 
 //-----------------------------------------------------------------------------
-int dbg_dap_cmd(uint8_t *data, int size, int rsize)
+int dbg_dap_cmd(uint8_t *data, int resp_size, int req_size)
 {
   uint8_t cmd = data[0];
   int res;
@@ -121,7 +121,7 @@ int dbg_dap_cmd(uint8_t *data, int size, int rsize)
   memset(hid_buffer, 0xff, report_size + 1);
 
   hid_buffer[0] = 0x00; // Report ID
-  memcpy(&hid_buffer[1], data, rsize);
+  memcpy(&hid_buffer[1], data, req_size);
 
   res = hid_write(handle, hid_buffer, report_size + 1);
   if (res < 0)
@@ -139,7 +139,7 @@ int dbg_dap_cmd(uint8_t *data, int size, int rsize)
   check(hid_buffer[0] == cmd, "invalid response received");
 
   res--;
-  memcpy(data, &hid_buffer[1], (size < res) ? size : res);
+  memcpy(data, &hid_buffer[1], (resp_size < res) ? resp_size : res);
 
   return res;
 }

--- a/dbg_win.c
+++ b/dbg_win.c
@@ -176,7 +176,7 @@ int dbg_get_report_size(void)
 }
 
 //-----------------------------------------------------------------------------
-int dbg_dap_cmd(uint8_t *data, int size, int rsize)
+int dbg_dap_cmd(uint8_t *data, int resp_size, int req_size)
 {
   uint8_t cmd = data[0];
   DWORD res;
@@ -184,7 +184,7 @@ int dbg_dap_cmd(uint8_t *data, int size, int rsize)
   memset(hid_buffer, 0xff, report_size + 1);
 
   hid_buffer[0] = 0x00; // Report ID
-  memcpy(&hid_buffer[1], data, rsize);
+  memcpy(&hid_buffer[1], data, req_size);
 
   if (FALSE == WriteFile(debugger_handle, (LPCVOID)hid_buffer, report_size + 1, &res, NULL))
     error_exit("debugger write()");
@@ -195,7 +195,7 @@ int dbg_dap_cmd(uint8_t *data, int size, int rsize)
   check(hid_buffer[1] == cmd, "invalid response received");
 
   res -= 2;
-  memcpy(data, &hid_buffer[2], (size < (int)res) ? size : (int)res);
+  memcpy(data, &hid_buffer[2], (resp_size < (int)res) ? resp_size : (int)res);
 
   return res;
 }


### PR DESCRIPTION
I personally had a hard time figuring out the difference between `size` and `rsize` since I assumed the `rsize` was the response, not the request size.

However this might be just me not being familiar with the source code. Would you accept this patch clarifying the semantics of the size parameters or do you deem it unnecessary?