### PR TITLE
target_get_ops should accept const char*

### DIFF
--- a/target.c
+++ b/target.c
@@ -116,7 +116,7 @@ void target_list(void)
 }
 
 //-----------------------------------------------------------------------------
-target_ops_t *target_get_ops(char *name)
+target_ops_t *target_get_ops(const char *name)
 {
   for (int i = 0; i < ARRAY_SIZE(targets); i++)
   {

--- a/target.h
+++ b/target.h
@@ -71,7 +71,7 @@ typedef struct
 
 /*- Prototypes --------------------------------------------------------------*/
 void target_list(void);
-target_ops_t *target_get_ops(char *name);
+target_ops_t *target_get_ops(const char *name);
 void target_check_options(target_options_t *options, int size, int align);
 void target_free_options(target_options_t *options);
 void target_fuse_commands(target_ops_t *ops, char *cmd);


### PR DESCRIPTION
Calling `target_get_ops` with a static string currently requires an unnecessary `strdup` since the `name` argument requires a non-const `char*`. This can be avoided since all operations inside `target_get_ops` already treat `name` as const.