### PR TITLE
dbg_webhid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 edbg
 edbg.exe
+edbg.js
+edbg.wasm
 

--- a/Makefile_webhid
+++ b/Makefile_webhid
@@ -1,0 +1,35 @@
+SOURCES =			\
+	dap.c			\
+	dbg_webhid.c		\
+	edbg.c			\
+	target.c		\
+	target_atmel_cm0p.c	\
+	target_atmel_cm3.c	\
+	target_atmel_cm4.c	\
+	target_atmel_cm7.c	\
+	target_atmel_cm4v2.c	\
+	target_mchp_cm23.c	\
+	target_st_stm32g0.c	\
+	target_gd_gd32f4xx.c	\
+	target_nu_m480.c	\
+
+
+.PHONY: all
+all: clean build
+
+
+.PHONY: clean
+clean:
+	@if [ -f 'edbg.js' ]; then	\
+		rm 'edbg.js';		\
+	fi
+
+	@if [ -f 'edbg.wasm' ]; then	\
+		rm 'edbg.wasm';		\
+	fi
+
+
+.PHONY: build
+build:
+	emcc -o 'edbg.js' --post-js 'dbg_webhid.js' -s INVOKE_RUN=0 -s 'EXPORTED_RUNTIME_METHODS=["callMain", "cwrap"]' -s 'EXPORTED_FUNCTIONS=["_main", "_dbg_webhid_set_debugger"]' -O3 -s ASYNCIFY=1 -s 'ASYNCIFY_IMPORTS=["dbg_enumerate", "dbg_dap_cmd"]' $(SOURCES)
+

--- a/dbg_webhid.c
+++ b/dbg_webhid.c
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2013-2021, Alex Taradov <alex@taradov.com>
+ *                          ooxi <violetland@mail.ru>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*- Includes ----------------------------------------------------------------*/
+#include "dbg.h"
+
+#include <emscripten.h>
+#include <stddef.h>
+
+/*- Implementations ---------------------------------------------------------*/
+
+//-----------------------------------------------------------------------------
+void dbg_webhid_set_debugger(debugger_t *debuggers, size_t debugger) {
+  debuggers[debugger].path = "/path";
+  debuggers[debugger].serial = "serial";
+  debuggers[debugger].wserial = 0;
+  debuggers[debugger].manufacturer = "manufacturer";
+  debuggers[debugger].product = "product";
+  debuggers[debugger].vid = 0;
+  debuggers[debugger].pid = 0;
+}
+
+//-----------------------------------------------------------------------------
+EM_JS(int, dbg_enumerate, (debugger_t *debuggers, int size), {
+  return Asyncify.handleAsync(async () => {
+    if (!Module.edbg.isHidAvailable())
+    {
+      throw new Error("WebHID not available");
+    }
+
+    console.error("dbg_enumerate stubbed, only one CMSIS-DAP adapter supported concurrently!");
+    const dbg_webhid_set_debugger = Module.cwrap("dbg_webhid_set_debugger", "void", ["number", "number"]);
+    dbg_webhid_set_debugger(debuggers, 0);
+
+    /* Return the value as you normally would.
+     */
+    return 1;
+  });
+});
+
+//-----------------------------------------------------------------------------
+// @warning Argument must not be named {@code debugger} since this is a fixed
+//     JavaScript statement
+//
+// @see https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Statements/debugger
+EM_JS(void, dbg_open, (debugger_t *debugger_), {
+  if (!Module.edbg.isHidAvailable())
+  {
+    throw new Error("WebHID not available");
+  }
+
+  console.error("dbg_open stubbed, will always use the first device!");
+  Module.edbg.device = Module.edbg.devices[0];
+});
+
+//-----------------------------------------------------------------------------
+// @warning I don't know how to get the report size from the WebHID device.
+//     However I also don't know how to access quite a lot of other information
+//     besides sending and receiving reports, thus it's quite likely that I'm
+//     just missing something
+EM_JS(int, dbg_get_report_size, (void), {
+  if (!Module.edbg.isHidAvailable())
+  {
+    throw new Error("WebHID not available");
+  }
+
+  return 64;  // TODO 128 is too big
+});
+
+//-----------------------------------------------------------------------------
+EM_JS(void, dbg_close, (void), {
+  if (!Module.edbg.isHidAvailable())
+  {
+    throw new Error("WebHID not available");
+  }
+
+  Module.edbg.device = null;
+  Module.edbg.close();
+});
+
+//-----------------------------------------------------------------------------
+EM_JS(int, dbg_dap_cmd, (uint8_t *data, int resp_size, int req_size), {
+  return Asyncify.handleAsync(async () => {
+    if (!Module.edbg.isHidAvailable())
+    {
+      throw new Error("WebHID not available");
+    }
+
+    if (null === Module.edbg.device)
+    {
+      throw new Error("No device opended by `dbg_open'");
+    }
+
+
+    /* We will temporarly set the {@code inputreport} event listener
+     * to fullfill exactly one Promise, which is the response to our
+     * request.
+     */
+    let onInputReport = null;
+
+    try {
+      /* {@code responsePromise} will be waited on after the
+       * request has been sent.
+       *
+       * It will automatically be rejected, if sending the
+       * request and receiving the response will be too slow.
+       *
+       * Otherwise it will be resolved as soon as the response
+       * has been received from the device
+       *
+       * TODO setTimeout + reject
+       */
+      const responsePromise = new Promise((resolve, reject) => {
+        const timeoutId = window.setTimeout(() => {
+          reject(new Error("Device did not respond to request"));
+        }, 2000);
+
+        onInputReport = (e) => {
+          window.clearTimeout(timeoutId);
+
+          const inputReport = new Uint8Array(e.data.buffer);
+
+          /* First value in response seems to be
+           * the request id? However I'm not 100%
+           * sure on that.
+           *
+           * It would mirror the behaviour of other
+           * dbg interfaces, however there one has
+           * to also specify the report id as part
+           * of the request data and not as a
+           * separate parameter.
+           */
+          writeArrayToMemory(inputReport.subarray(1), data);
+          resolve(inputReport.length - 1);
+        };
+
+        Module.edbg.device.addEventListener("inputreport", onInputReport);
+      });
+
+      /* @see https://github.com/ataradov/edbg/blob/master/dbg_lin.c#L198
+       */
+      const outputReportId = 0x00;
+      const outputReport = new Uint8Array(Module.HEAPU8.subarray(data, data + req_size));
+
+      await Module.edbg.device.sendReport(outputReportId, outputReport);
+      return await responsePromise;
+
+    } finally {
+      Module.edbg.device.removeEventListener("inputreport", onInputReport);
+    }
+  });
+});
+

--- a/dbg_webhid.js
+++ b/dbg_webhid.js
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2013-2021, Alex Taradov <alex@taradov.com>
+ *                          ooxi <violetland@mail.ru>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+Module.edbg = {
+    isHidAvailable: () => {
+        return "hid" in navigator;
+    },
+
+
+    device: null,
+    devices: [],
+
+
+    /* Let the user select which devices should be opened
+     *
+     * @warning Google Chrome requires requesting devices to be called in
+     *     response to a user action
+     * @warning https://wicg.github.io/webhid/#dom-hid-getdevices will not tell
+     *     you any devices in Google Chrome, you have to request filter them
+     */
+    refreshDevices: async () => {
+        if (!Module.edbg.isHidAvailable()) {
+            throw new Error("WebHID not available");
+        }
+
+        /* @warning https://wicg.github.io/webhid/#dom-hid-getdevices will not
+         *     tell you any devices in Google Chrome, you have to request filter
+         *     them
+         */
+        const allDevices = await navigator.hid.requestDevice({
+            "filters": []
+        });
+        let openedDevices = [];
+
+        for (const device of allDevices) {
+            if (!device.opened) {
+
+                /* @warning This will on Ubuntu Mate 21.04 since
+                 *     `/dev/hidrawX` is not accessible to the
+                 *     user by default.
+                 *
+                 *     chowing the device will solve the problem.
+                 */
+                await device.open();
+            }
+
+            openedDevices.push(device);
+        };
+
+        Module.edbg.devices = openedDevices;
+    },
+
+
+    /* Will be resolved by {@code dbg_close} in order to notify external code
+     * that edbg has finished.
+     *
+     * @warning There ought to be a better way, however I'm not familiar with
+     *     one
+     */
+    close: null,
+    running: null,
+};
+
+
+Module.edbg.running = new Promise((resolve) => {
+    Module.edbg.close = resolve;
+});
+

--- a/edbg.html
+++ b/edbg.html
@@ -1,0 +1,184 @@
+<!doctype html>
+<html lang="en-us">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <title>edbg</title>
+  </head>
+  <body>
+    <button id="edbg-device-refresh" disabled="disabled">🗘</button>
+
+    <select id="edbg-device-list" disabled="disabled">
+      <option value="">(devices need to be refreshed first)</option>
+    </select>
+
+    <input id="edbg-parameters" type="text" placeholder="--target samd11 --verbose --read --file file.bin" disabled="disabled" />
+    <button id="edbg-run" disabled="disabled">▶</button>
+
+    <div id="edbg-output"></div>
+
+    <script type='text/javascript'>
+let $deviceRefreshButton = document.getElementById("edbg-device-refresh");
+let $deviceListSelect = document.getElementById("edbg-device-list");
+let $parametersInput = document.getElementById("edbg-parameters");
+let $runButton = document.getElementById("edbg-run");
+let $outputDiv = document.getElementById("edbg-output");
+
+
+const disableUi = () => {
+  $deviceRefreshButton.setAttribute("disabled", "disabled");
+  $deviceListSelect.setAttribute("disabled", "disabled");
+  $parametersInput.setAttribute("disabled", "disabled");
+  $runButton.setAttribute("disabled", "disabled");
+};
+
+const enableUi = () => {
+  $deviceRefreshButton.removeAttribute("disabled");
+  $deviceListSelect.removeAttribute("disabled");
+  $parametersInput.removeAttribute("disabled");
+  $runButton.removeAttribute("disabled");
+};
+
+/* @see https://stackoverflow.com/a/3955238
+ *
+ * @author Gabriel McAdams
+ * @author FZs
+ */
+const removeAllChildren = ($element) => {
+  while ($element.firstChild) {
+    $element.removeChild($element.lastChild);
+  }
+};
+
+
+
+var Module = {
+  onRuntimeInitialized: async () => {
+    console.log("Module runtime initialized");
+    enableUi();
+    //await Module.callMain(["--list"]);
+  },
+
+  print: function (text) {
+    if (arguments.length > 1) {
+      text = Array.prototype.slice.call(arguments).join(' ');
+    }
+
+    let $message = document.createElement("div");
+    $message.setAttribute("class", "edbg-output-message");
+    $message.appendChild(document.createTextNode(text));
+    $outputDiv.appendChild($message);
+  },
+
+  printErr: function (text) {
+    if (arguments.length > 1) {
+      text = Array.prototype.slice.call(arguments).join(' ');
+    }
+
+    let $error = document.createElement("div");
+    $error.setAttribute("class", "edbg-output-error");
+    $error.appendChild(document.createTextNode("Error: " + text));
+    $outputDiv.appendChild($error);
+  },
+};
+
+
+
+/* Sends a Uint8Array as download to the user
+ *
+ * @author Stefan
+ * @author drivfe
+ *
+ * @see https://stackoverflow.com/a/33622881
+ */
+const downloadBlob = (data, fileName, mimeType) => {
+  let blob, url;
+  blob = new Blob([data], {
+    type: mimeType
+  });
+  url = window.URL.createObjectURL(blob);
+
+  const downloadURL = (data, fileName) => {
+    let a = document.createElement("a");
+    a.href = data;
+    a.download = fileName;
+    document.body.appendChild(a);
+    a.style = 'display: none';
+    a.click();
+    a.remove();
+  };
+
+  downloadURL(url, fileName);
+  setTimeout(function() {
+    return window.URL.revokeObjectURL(url);
+  }, 1000);
+};
+
+
+
+$deviceRefreshButton.onclick = async () => {
+  removeAllChildren($outputDiv);
+
+  try {
+    await Module.edbg.refreshDevices();
+
+    removeAllChildren($deviceListSelect);
+
+    Module.edbg.devices.forEach((device, deviceIdx) => {
+      let $option = document.createElement("option");
+      $option.setAttribute("value", deviceIdx);
+      $option.appendChild(document.createTextNode(device.productName));
+      $deviceListSelect.appendChild($option);
+    });
+
+  } catch (e) {
+    console.error("Caught unexpected exception while refreshing devices", e);
+    Module.printErr(e.message);
+  }
+};
+
+$runButton.onclick = async () => {
+  removeAllChildren($outputDiv);
+  disableUi();
+
+  try {
+    const deviceIdx = $deviceListSelect.value;
+
+    if ('' === deviceIdx) {
+      throw new Error("You have to refresh (🗘) the device list first");
+    }
+    if (!Module.edbg.devices.hasOwnProperty(deviceIdx)) {
+      throw new Error("Cannot find device `" + deviceIdx + "', please try refreshing device list!");
+    }
+
+    /* @warning This will fail when presented an with an argument
+     *     like {@code -f "my file"}
+     */
+    const parameters = (() => {
+      if ('' === $parametersInput.value) {
+//        return ["--help"];
+//        return ["--target", "samd11", "--verbose", "--read", "--file", "file.bin"];
+        return ["--target", "samd21", "--verbose", "--read", "--file", "file.bin"];
+      }
+      return $parametersInput.value.split(" ");
+    })();
+
+    await Module.callMain(parameters);
+    await Module.edbg.running;
+
+    const fileContent = FS.readFile("file.bin", {
+      "encoding": "binary",
+    });
+    downloadBlob(fileContent, "file.bin", "application/octet-stream");
+
+  } catch (e) {
+    console.error("Caught unexpected exception while running edbg", e);
+    Module.printErr(e.message);
+  }
+};
+
+    </script>
+    <script async type="text/javascript" src="edbg.js"></script>
+  </body>
+</html>
+


### PR DESCRIPTION
Bootstrapped cross compiling edbg for the web using [emscripten](https://emscripten.org/) and [WebHID](https://wicg.github.io/webhid/). Tested in Google Chrome on Windows and Linux with both free-dap as well as Xplained boards. [Should also work in Microsoft Edge](https://caniuse.com/webhid). free-dap worked on both Linux and Windows, however Xplained only worked on Windows:


## Select HID device

<img width="493" alt="select-device" src="https://user-images.githubusercontent.com/2611835/117007846-6282dc00-acea-11eb-81dd-0e32526f7d90.png">


## Read firmware from Xplained in Google Chrome on Windows

<img width="585" alt="read-firmware" src="https://user-images.githubusercontent.com/2611835/117007842-61ea4580-acea-11eb-915e-8f4f743f6a46.png">


## Known issues

* When using Linux (at least Ubuntu Mate 21.04) you must own `/dev/hidrawX`, otherwise Google Chrome cannot access the HID device.
* The build currently does not use modularization, thus you have to refresh to run edbg again
* Currently using a separate Makefile and not having GitHub Actions integration

This pull request is a preliminary request for comments. In my opinion it would be great if we could offer edbg functionality on the web.