### PR TITLE
hidapi dependency no longer required

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ you will need:
 
  * Windows: none
  * Linux: libudev-dev
- * Mac OS X: libhidapi (can be installed via [brew](http://macappstore.org/hidapi/))
+ * Mac OS X: none
 
 ## Usage
 ```


### PR DESCRIPTION
By using the native MacOS APIs, 2cc96ee782a50dff2ba183fbe201403f48489b82 removed the dependency on hidapi